### PR TITLE
Add PNG export option

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     <button id="finishBtn" class="btn btn-success">Finish</button>
     <button id="undoBtn" class="btn btn-warning">Undo</button>
     <button id="clearBtn" class="btn btn-danger">Clear</button>
+    <button id="exportBtn" class="btn btn-secondary">Export PNG</button>
     <div class="input-group" style="width:auto;">
       <label class="input-group-text" for="unitSel">Units</label>
       <select id="unitSel" class="form-select form-select-sm">
@@ -126,6 +127,7 @@
     document.getElementById('finishBtn').onclick=()=>{if(verts.length>=3){closed=true;preview=null;if(railFlags.length<verts.length)railFlags.length=verts.length;draw();}};
     document.getElementById('undoBtn').onclick=()=>{if(closed)closed=false;else{verts.pop();railFlags.pop();}preview=null;draw();};
     document.getElementById('clearBtn').onclick=()=>{verts=[];railFlags=[];preview=null;closed=false;hoverIdx=null;draw();};
+    document.getElementById('exportBtn').onclick=()=>{const link=document.createElement('a');link.href=cvs.toDataURL('image/png');link.download='deck.png';link.click();};
   })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add toolbar button to export the deck drawing as a PNG file
- implement export handler using `toDataURL`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f1f569ee0833288c1576c09d31d7d